### PR TITLE
Add Terraform and Ansible configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # terraform-ansible-lab
 Laboratório da Codaqui para testar Terraform e Ansible
+
+## Prerequisites
+
+- Terraform installed
+- Ansible installed
+- Azure account
+
+## Setup
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/codaqui/terraform-ansible-lab.git
+   cd terraform-ansible-lab
+   ```
+
+## Terraform
+
+1. Navigate to the `terraform` directory:
+   ```sh
+   cd terraform
+   ```
+
+2. Initialize Terraform:
+   ```sh
+   terraform init
+   ```
+
+3. Apply the Terraform configuration to create the virtual machines:
+   ```sh
+   terraform apply
+   ```
+
+4. Note the public IP addresses of the virtual machines from the Terraform output.
+
+## Ansible
+
+1. Navigate to the `ansible` directory:
+   ```sh
+   cd ansible
+   ```
+
+2. Update the `hosts` file with the public IP addresses of the virtual machines.
+
+3. Run the Ansible playbook to install Apache on the virtual machines:
+   ```sh
+   ansible-playbook -i hosts playbook.yml
+   ```

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,3 @@
+[azure_vms]
+<public_ip_address_1>
+<public_ip_address_2>

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Install Apache on Azure VMs
+  hosts: azure_vms
+  remote_user: azureuser
+  become: yes
+  tasks:
+    - name: Update apt package list
+      apt:
+        update_cache: yes
+
+    - name: Install Apache
+      apt:
+        name: apache2
+        state: present
+
+    - name: Start and enable Apache service
+      systemd:
+        name: apache2
+        state: started
+        enabled: yes

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,106 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "main" {
+  name                = var.virtual_network_name
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_subnet" "main" {
+  name                 = var.subnet_name
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_interface" "main" {
+  name                = "main-nic"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.main.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.main.id
+  }
+}
+
+resource "azurerm_public_ip" "main" {
+  name                = "main-pip"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_virtual_machine" "main" {
+  name                  = "main-vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = [azurerm_network_interface.main.id]
+  vm_size               = var.vm_size
+
+  storage_os_disk {
+    name              = "main-os-disk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = "main-vm"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}
+
+resource "azurerm_virtual_machine" "secondary" {
+  name                  = "secondary-vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = [azurerm_network_interface.main.id]
+  vm_size               = var.vm_size
+
+  storage_os_disk {
+    name              = "secondary-os-disk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = "secondary-vm"
+    admin_username = var.admin_username
+    admin_password = var.admin_password
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ip_addresses" {
+  description = "The public IP addresses of the virtual machines"
+  value       = [azurerm_public_ip.main.ip_address, azurerm_public_ip.secondary.ip_address]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "The location of the resource group"
+  type        = string
+}
+
+variable "vm_size" {
+  description = "The size of the virtual machines"
+  type        = string
+}
+
+variable "admin_username" {
+  description = "The admin username for the virtual machines"
+  type        = string
+}
+
+variable "admin_password" {
+  description = "The admin password for the virtual machines"
+  type        = string
+}
+
+variable "virtual_network_name" {
+  description = "The name of the virtual network"
+  type        = string
+}
+
+variable "subnet_name" {
+  description = "The name of the subnet"
+  type        = string
+}


### PR DESCRIPTION
Add Terraform configuration to create two virtual machines in Azure and Ansible playbook to install Apache on them.

* **Terraform Configuration:**
  - Add `terraform/main.tf` to define Azure provider, resource group, virtual network, subnet, network interface, public IP, and two virtual machines with Ubuntu 22.04 image.
  - Add `terraform/variables.tf` to define variables for resource group name, location, VM size, admin username, admin password, virtual network name, and subnet name.
  - Add `terraform/outputs.tf` to output the public IP addresses of the virtual machines.

* **Ansible Playbook:**
  - Add `ansible/playbook.yml` to define tasks to update package list, install Apache, and start and enable Apache service on the virtual machines.
  - Add `ansible/hosts` to define inventory file with IP addresses of the virtual machines.

* **README.md:**
  - Add instructions to use Terraform to create virtual machines.
  - Add instructions to use Ansible to install Apache on the virtual machines.
  - Add prerequisites and setup steps for Terraform and Ansible.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codaqui/terraform-ansible-lab?shareId=b9009222-7baa-425c-8955-a2f463a959e9).