### PR TITLE
Add ignore files and update readme with variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Laboratório da Codaqui para testar Terraform e Ansible
 
 4. Note the public IP addresses of the virtual machines from the Terraform output.
 
+### Declaring Variables
+
+Before running the Terraform commands, you need to declare the following variables in a `terraform.tfvars` file or pass them as command-line arguments:
+
+- `resource_group_name`: The name of the resource group
+- `location`: The location of the resource group
+- `vm_size`: The size of the virtual machines
+- `admin_username`: The admin username for the virtual machines
+- `admin_password`: The admin password for the virtual machines
+- `virtual_network_name`: The name of the virtual network
+- `subnet_name`: The name of the subnet
+
+Example `terraform.tfvars` file:
+```hcl
+resource_group_name = "my-resource-group"
+location = "East US"
+vm_size = "Standard_B1s"
+admin_username = "azureuser"
+admin_password = "P@ssw0rd1234"
+virtual_network_name = "my-vnet"
+subnet_name = "my-subnet"
+```
+
 ## Ansible
 
 1. Navigate to the `ansible` directory:
@@ -43,7 +66,20 @@ Laboratório da Codaqui para testar Terraform e Ansible
 
 2. Update the `hosts` file with the public IP addresses of the virtual machines.
 
+### Declaring Variables
+
+Before running the Ansible playbook, you need to declare the following variables in a `vars.yml` file or pass them as command-line arguments:
+
+- `ansible_user`: The remote user for the virtual machines
+- `ansible_password`: The password for the remote user
+
+Example `vars.yml` file:
+```yaml
+ansible_user: azureuser
+ansible_password: P@ssw0rd1234
+```
+
 3. Run the Ansible playbook to install Apache on the virtual machines:
    ```sh
-   ansible-playbook -i hosts playbook.yml
+   ansible-playbook -i hosts playbook.yml --extra-vars "@vars.yml"
    ```

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,3 @@
+*.retry
+*.log
+*.tmp

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,3 @@
+*.tfstate
+*.tfstate.backup
+.terraform/


### PR DESCRIPTION
Add `.gitignore` files to `ansible` and `terraform` directories and update `README.md` with variable declarations and command updates.

* **Ansible `.gitignore`**: Add `*.retry`, `*.log`, and `*.tmp` to ignore retry, log, and temporary files.
* **Terraform `.gitignore`**: Add `*.tfstate`, `*.tfstate.backup`, and `.terraform/` to ignore state files and Terraform directory.
* **README.md**:
  - Add a section for declaring variables in the `terraform` directory.
  - Add a section for declaring variables in the `ansible` directory.
  - Update the command to run the Ansible playbook with the declared variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codaqui/terraform-ansible-lab?shareId=00060ef5-0659-47b3-976d-207234e52c55).