### PR TITLE
Fix static IP allocation for Standard SKU public IP addresses

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,14 +47,14 @@ resource "azurerm_public_ip" "main" {
   name                = "main-pip"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_public_ip" "secondary" {
   name                = "main-pip"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
 }
 
 resource "azurerm_virtual_machine" "main" {


### PR DESCRIPTION
Change the allocation method to "Static" for Standard SKU public IP addresses in `terraform/main.tf`.

* Change `allocation_method` to "Static" in `azurerm_public_ip` resource on line 46.
* Change `allocation_method` to "Static" in `azurerm_public_ip` resource on line 53.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codaqui/terraform-ansible-lab?shareId=646ad1dc-a105-4cb8-a013-c900cf39f171).